### PR TITLE
unittest.sh now uses xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,12 @@ azure-storage-blob = { version = "^12.0.0", optional = true }
 cffi = {version = "^1.14.0", optional = true}
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.4.3"
+pytest = "^6.0.0"
 pytest-cov = "^2.10"
 requests = "^2"
 flake8 = "*"
 pytype = "*"
+pytest-xdist = "^2.1.0"
 
 [tool.poetry.extras]
 redis = ["redis"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # install poetry and the dev-dependencies of the project
 python -m pip install poetry
 python -m poetry update --lock

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # run various linters
 poetry run flake8 --max-line-length 120 yellowbox tests
 poetry run python -c "import sys; sys.exit(sys.version_info < (3,8,0))"

--- a/scripts/unittest.sh
+++ b/scripts/unittest.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 # run the unittests with branch coverage
-python -m poetry run python -m pytest --cov-branch --cov=./yellowbox --cov-report=xml tests/
+poetry run pytest -n auto --dist loadfile --cov-branch --cov=./yellowbox --cov-report=xml tests/


### PR DESCRIPTION
upgrade pytest to 6.0.0 to support xdist.

fixed scripts to be chmodded + contain shebang