### PR TITLE
RabbitMQService: On start & retries scenario, suppress ConnectionError's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## unreleased
 ### Added
 * new properties in `BlobStorageService`: `endpoint_url`, `container_endpoint_url`, `account_credentials`.
+### Fixed
+* `RabbitMQService` suppress `ConnectionError`s on startup retries.
 ## 0.3.1
 ### Fixed
 * `LogstashService` correctly reconstructs fragmented data.
@@ -56,7 +58,7 @@
 * Bug where services would fail if trying to run a non-pulled image.
 * Issue where the rabbit service test was not tries on the main tag.
 * restored some network tests
-* Bug in `connect` where networks would try to disconnect containers that have since been removed. 
+* Bug in `connect` where networks would try to disconnect containers that have since been removed.
 * Bug in `KafkaService` where the service would try to kill if the containers even if they are no longer running.
 * Bug in `KafkaService` where the network would not disconnect from the server after.
 * Bug in `RabbitMQService` where the container would no kill cleanly

--- a/yellowbox/extras/rabbit_mq.py
+++ b/yellowbox/extras/rabbit_mq.py
@@ -48,7 +48,7 @@ class RabbitMQService(SingleContainerService, RunMixin):
     def start(self, retry_spec: Optional[RetrySpec] = None):
         super().start()
         retry_spec = retry_spec or RetrySpec(attempts=20)
-        conn = retry_spec.retry(self.connection, AMQPConnectionError)
+        conn = retry_spec.retry(self.connection, (AMQPConnectionError, ConnectionError))
         conn.close()
         return self
 


### PR DESCRIPTION
Closes #56 